### PR TITLE
Extra braces in getInheritance()?

### DIFF
--- a/ColdDoc.cfc
+++ b/ColdDoc.cfc
@@ -202,7 +202,6 @@
 <cffunction name="getInheritence" hint="gets an array of the classes that this metadata extends, in order of extension" access="private" returntype="array" output="false">
 	<cfargument name="metadata" hint="the metadata to look at" type="struct" required="Yes">
 	<cfscript>
-		{
 			var localmeta = arguments.metadata;
 			//ignore top level
 			var inheritence = [];
@@ -223,7 +222,6 @@
 			}
 
 			return inheritence;
-		}
 	</cfscript>
 </cffunction>
 


### PR DESCRIPTION
The cfscript was enclosed in {} and CF8 complained about locally scoped vars.  I removed them and everything seemed to work.  CF 9 works either way.
