### PR TITLE
Incorrect component reported in warning when filename contains dots.

### DIFF
--- a/ColdDoc.cfc
+++ b/ColdDoc.cfc
@@ -92,7 +92,7 @@
                     packagePath = arguments.inputSource[i].inputMapping;
                 }
 
-                cfcName = ListGetAt(name, 1, ".");
+                cfcName = Left(name, len(name)-4);
 
 				try
 				{


### PR DESCRIPTION
ColdDoc falls over on CFCs with dots in their filename, but reports the incorrect component path when logging this error.

e.g. for `/path/to/object.archive.cfc` the log would report `path.to.object` as not existing.

It's possible ColdDoc should report a different error (e.g. invalid cfc filename), but as a quick fix, simply removing the `.cfc` from the end of the filename results in a more obvious error message.
