### PR TITLE
Compatibility with open bluedragon 3.0

### DIFF
--- a/ColdDoc.cfc
+++ b/ColdDoc.cfc
@@ -71,11 +71,11 @@
 		var i = 0;
 		var implements = 0;
 		var fullextends = 0;
+		var cfoCompatibility = createObject("component","colddoc.compatibility");
 	</cfscript>
 
     <cfloop index="i" from="1" to="#ArrayLen(arguments.inputSource)#">
-
-        <cfdirectory action="list" directory="#arguments.inputSource[i].inputDir#" recurse="true" name="qFiles" filter="*.cfc">
+        <cfset qFiles = cfoCompatibility.directory_list(directory="#arguments.inputSource[i].inputDir#",recurse=true,filter_cfc=true)>
 
         <cfloop query="qFiles">
             <cfscript>

--- a/compatibility.cfc
+++ b/compatibility.cfc
@@ -1,0 +1,70 @@
+<cfcomponent hint="Core class for ColdDoc documentation generation framework" output="false">
+	<cffunction name="directory_list" access="public" returntype="query" hint="Compatability function that ensures the result from a recursive directory listing is the same accross railo, adobe coldfusion and openbd.">
+		<cfargument name="directory" type="string" required="yes">
+		<cfargument name="filter_cfc" type="boolean" required="false" default="false">
+		<cfset var qFiles = "">
+		<cfset var filter = "">
+
+		<cfif server.coldfusion.productname EQ "BlueDragon">
+			<cfif arguments.filter_cfc>
+				<cfset filter = ".cfc">
+			</cfif>
+			<cfset qFiles = openbd_cfdirectory(directory=arguments.directory,recurse=true,filter="#filter#")>
+		<cfelse>
+			<cfif arguments.filter_cfc>
+				<cfset filter = "*.cfc">
+			</cfif>
+			<cfdirectory action="list" directory="#arguments.directory#" recurse="true" name="qFiles" filter="#filter#">
+		</cfif>
+
+		<cfreturn qFiles>
+	</cffunction>
+
+	<cffunction name="openbd_cfdirectory" access="private" returntype="query" output="false" hint="Returns recursive directory listings on open bluedragon in the same format as Adobe Coldfusion and Railo.">
+		<cfargument name="directory" type="string" required="yes">
+		<cfargument name="recurse" type="string" required="yes">
+		<cfargument name="filter" type="string" required="false" default="">
+		<cfset var qResult = queryNew("name,size,type,directory,dateLastModified,attributes,mode")>
+		<cfset var qDir = "">
+		<cfset var qChild = "">
+
+		<cfdirectory action="list" directory="#arguments.directory#" recurse="false" name="qDir">
+
+		<cfloop query="qDir">
+			<cfscript>
+			if(arguments.filter EQ "" 	OR 	(qDir.type EQ "File" AND reFindNoCase(arguments.filter,qDir.name)))
+			{
+				queryaddrow(qResult,1);
+				querysetcell(qResult,"name",qDir.name);
+				querysetcell(qResult,"size",qDir.size);
+				querysetcell(qResult,"type",qDir.type);
+				querysetcell(qResult,"directory",qDir.directory);
+				querysetcell(qResult,"dateLastModified",qDir.dateLastModified);
+				querysetcell(qResult,"attributes",qDir.attributes);
+				querysetcell(qResult,"mode",qDir.mode);
+			}
+			</cfscript>
+
+			<cfif arguments.recurse AND qDir.type EQ "Dir">
+				<cfset qChild = openbd_cfdirectory(directory="#qDir.directory#/#qDir.name#",recurse=true,filter="#arguments.filter#")>
+				<cfloop query="qChild">
+					<cfscript>
+					if(arguments.filter EQ "" 	OR 	(qChild.type EQ "File" AND reFindNoCase(arguments.filter,qChild.name)))
+					{
+						queryaddrow(qResult,1);
+						querysetcell(qResult,"name",qChild.name);
+						querysetcell(qResult,"size",qChild.size);
+						querysetcell(qResult,"type",qChild.type);
+						querysetcell(qResult,"directory",qChild.directory);
+						querysetcell(qResult,"dateLastModified",qChild.dateLastModified);
+						querysetcell(qResult,"attributes",qChild.attributes);
+						querysetcell(qResult,"mode",qChild.mode);
+					}
+					</cfscript>
+				</cfloop>
+			</cfif>
+		</cfloop>
+
+		<cfreturn qResult>
+	</cffunction>
+</cfcomponent>

--- a/strategy/AbstractTemplateStrategy.cfc
+++ b/strategy/AbstractTemplateStrategy.cfc
@@ -4,8 +4,8 @@
 <!------------------------------------------- PUBLIC ------------------------------------------->
 
 <cfscript>
-	instance.static.META_ABSTRACT = "colddoc:abstract";
-	instance.static.META_GENERIC = "colddoc:generic";
+	instance.static.META_ABSTRACT = "colddoc_abstract";
+	instance.static.META_GENERIC = "colddoc_generic";
 </cfscript>
 
 <cffunction name="run" hint="Run this strategy" access="public" returntype="void" output="false">
@@ -53,7 +53,7 @@
 				}
 
 				node = node[item];
-      </cfscript>
+            </cfscript>
 		</cfloop>
 	</cfloop>
 
@@ -68,7 +68,8 @@
 	<cfscript>
 		var startCall = arguments.startCommand;
 		var endCall = arguments.endCommand;
-		var key = 0;
+		var keys = 0;
+		var node = 0;
 		var thisArgs = 0;
 
 		if(NOT StructKeyExists(args, "fullname"))
@@ -105,7 +106,7 @@
 	<cfscript>
 		var qFunctions = QueryNew("name,metadata");
 		var func = 0;
-		var results = 0;
+		var result = 0;
 		var cache = getFunctionQueryCache();
 
 		if(StructKeyExists(cache, arguments.metadata.name))
@@ -154,7 +155,7 @@
 	{
 		var objectname = getObjectName(arguments.class);
 		var lenCount = Len(arguments.class) - (Len(objectname) + 1);
-	       
+
 		if( lenCount gt 0 )
 		{
 		    return Left(arguments.class, lenCount);
@@ -177,7 +178,7 @@
 		var qClass = getMetaSubQuery(arguments.qMetaData, "LOWER(package)=LOWER('#packageName#') AND LOWER(name)=LOWER('#objectName#')");
 
 		return qClass.recordCount;
-  </cfscript>
+    </cfscript>
 </cffunction>
 
 <cffunction name="typeExists" hint="whether a type exists at all - be it class name, or primitive type" access="private" returntype="boolean" output="false">
@@ -186,7 +187,7 @@
 	<cfargument name="package" hint="the package the class comes from" type="string" required="Yes">
 	<cfscript>
 		return isPrimitive(arguments.className) OR classExists(argumentCollection=arguments);
-	</cfscript>
+    </cfscript>
 </cffunction>
 
 <cffunction name="resolveClassName" hint="resolves a class name that may not be full qualified" access="private" returntype="string" output="false">
@@ -199,7 +200,7 @@
 		}
 
 		return arguments.className;
-	</cfscript>
+    </cfscript>
 </cffunction>
 
 <cffunction name="getMetaSubQuery" hint="returns a query on the meta query" access="private" returntype="query" output="false">
@@ -336,18 +337,17 @@
 	<cfargument name="fromDir" hint="the input directory" type="string" required="Yes">
 	<cfargument name="toDir" hint="the output directory" type="string" required="Yes">
 	<cfscript>
-		var qFiles = 0;
+		var files = 0;
 		var currentDir = "";
 		var safeDir = "";
 
 		arguments.fromDir = replaceNoCase(arguments.fromDir, "\", "/", "all");
 		arguments.toDir = replaceNoCase(arguments.toDir, "\", "/", "all");
 	</cfscript>
-	
-	<cfdirectory action="list" directory="#arguments.fromDir#" recurse="true" name="qFiles">
+
+	<cfinvoke component="colddoc.compatibility" method="directory_list" directory="#arguments.fromDir#" returnvariable="qFiles">
 
 	<cfoutput group="directory" query="qFiles">
-
 		<cfset safeDir = replaceNoCase(directory, "\", "/", "all") />
 
 		<!--- dodge svn directories --->
@@ -379,13 +379,13 @@
 <cffunction name="isAbstractClass" hint="is this class annotated as an abstract class?" access="private" returntype="boolean" output="false">
 	<cfargument name="class" hint="the class name" type="string" required="Yes">
 	<cfargument name="package" hint="the package the class comes from" type="string" required="Yes">
+
 	<cfscript>
 		var meta = 0;
 		arguments.class = resolveClassName(arguments.class, arguments.package);
-
 		meta = getComponentMetadata(arguments.class);
 
-		if(structKeyExists(meta, instance.static.META_ABSTRACT))
+		if(structKeyExists(meta,instance.static.META_ABSTRACT))
 		{
 			return meta[instance.static.META_ABSTRACT];
 		}
@@ -449,5 +449,7 @@
 		<cfabort>
 		</cfif>
 </cffunction>
+
+
 
 </cfcomponent>


### PR DESCRIPTION
Added a patch for compatibility with open bluedragon 3.0

The recurse and filter options for cfdirectory work differently in
openbd. Added a compatibility component which uses a custom method to
emulate the same behaviour for cfdirectoy in openbluedragon.

Changed the keys for META_ABSTRACT and META_GENERIC as openbluedragon
throws an error when a structure key name contains a colon.

The patch has been tested with openbd 3.0 and Railo 4
