### PR TITLE
Added ability to scan recursively or non-recursively within folders

### DIFF
--- a/ColdDoc.cfc
+++ b/ColdDoc.cfc
@@ -13,6 +13,7 @@
 <cffunction name="generate" hint="generates the documentation" access="public" returntype="void" output="false">
 	<cfargument name="inputSource" hint="either, the string directory source, OR an array of structs containing inputDir and inputMapping key" type="any" required="yes">
 	<cfargument name="inputMapping" hint="the base mapping for the folder. Only required if the inputSource is a string." type="string" required="false" default="">
+	<cfargument name="recursive" hint="the indicator to search within directories recursively. Only required if the inputSource is a string." type="string" required="false" default="false">
 	<cfscript>
 		var qMetaData = 0;
 		var source = 0;
@@ -25,7 +26,7 @@
 
 		if(isSimpleValue(arguments.inputSource))
 		{
-			source = [{ inputDir=arguments.inputSource, inputMapping=arguments.inputMapping }];
+			source = [{ inputDir=arguments.inputSource, inputMapping=arguments.inputMapping, recursive=arguments.recursive }];
 		}
 		else
 		{
@@ -75,7 +76,7 @@
 
     <cfloop index="i" from="1" to="#ArrayLen(arguments.inputSource)#">
 
-        <cfdirectory action="list" directory="#arguments.inputSource[i].inputDir#" recurse="true" name="qFiles" filter="*.cfc">
+        <cfdirectory action="list" directory="#arguments.inputSource[i].inputDir#" recurse="#arguments.inputSource[i].recursive" name="qFiles" filter="*.cfc">
 
         <cfloop query="qFiles">
             <cfscript>

--- a/run.cfm
+++ b/run.cfm
@@ -7,7 +7,17 @@ Let's generate our default HTML documentation on myself:
 	strategy = createObject("component", "colddoc.strategy.api.HTMLAPIStrategy").init(expandPath("./docs"), "ColdDoc 1.0");
 	colddoc.setStrategy(strategy);
 
-	colddoc.generate(expandPath("/colddoc"), "colddoc");
+	// Let's give flexibility to user to make choice of the folders within application which need to be documented
+	rootFolder = expandPath("/");
+	path_mapping = [
+		,	{inputDir="#rootFolder#",		inputMapping="colddoc",			recursive="false"}
+		,	{inputDir="#rootFolder#\strategy\api",	inputMapping="colddoc.strategy.api",	recursive="true"}
+		];
+
+	colddoc.generate(path_mapping);
+	
+	// Or diretly specify path and mapping to generate function
+	//colddoc.generate(expandPath("/colddoc"), "colddoc");
 </cfscript>
 
 <h1>Done!</h1>


### PR DESCRIPTION
There may be a requirement where user do not want to document all folders as some folders may contain third-party libraries. So, let user make a choice of the folders which he wants to be documented non-recursively. For example, the application root folder which should be scanned non-recursively as user may want to generate documentation of few folders only.
